### PR TITLE
change 'Customization download' to match the other headings

### DIFF
--- a/download.html
+++ b/download.html
@@ -252,7 +252,7 @@
                       <p class="lead"><a href="https://github.com/mastercomfig/mastercomfig/releases/latest/download/mastercomfig-lowmem-addon.vpk" class="text-light" id="lowmem-dl" style="display: none"><span class="fa fa-download fa-fw"></span> Download Low Memory addon VPK</a></p>
                     </div>
                     <hr>
-                    <h5><b><span class="fa fa-wrench fa-fw"></span> Customization download</b></h5>
+                    <h2><span class="fa fa-wrench fa-fw"></span> Customization download</h2>
                     <p>Create a <code>user</code> folder in <code>tf/cfg</code> folder and drop the files in there to override mastercomfig with your selected customizations!</p>
                     <noscript>Note: Customizations require JavaScript.</noscript>
                     <p class="lead"><b><a class="" id="custom-dl"><span class="fa fa-download fa-fw"></span> Download customizations </a></b></p>


### PR DESCRIPTION
I am fairly certain that this will eliminate most of the confusion regarding the separate customizations download.