### PR TITLE
add gamemode and autostart url search parameters

### DIFF
--- a/src/pages/quickplay.astro
+++ b/src/pages/quickplay.astro
@@ -133,6 +133,10 @@ const gamemodes = [
 
         import useQuickplayStore from "@store/quickplay";
 
+        const urlparms = new URLSearchParams(window.location.search);
+        if (urlparms.has("gm")) {
+          useQuickplayStore.getState().setGamemode(urlparms.get("gm"))
+        }
         document.addEventListener("astro:page-load", () => {
           const codeLookup = [
             "any",
@@ -189,6 +193,9 @@ const gamemodes = [
                 carousel = null;
               }
             });
+          }
+          if (urlparms.has("autostart")) {
+            playNow.click()
           }
         });
       </script>


### PR DESCRIPTION
I tried to be as minimal as possible since I'm not experienced with web development

This change will allow hud creators to integrate the app a little bit better inside the game, reducing the amount of clicks needed from the user when coming from a hud integration to their browser.

Since the gamemode selection is not persistent in idbstorege, I don't think this will affect regular usage of the app.

I refrained from adding parameters for the customization settings because there doesn't seem to be an easy way to make use of them inside a hud, so there would be no real use case currently.

Thank you for your work!