### PR TITLE
Add the option for quickplay users to join servers with modded gameplay

### DIFF
--- a/src/components/quickplay/CustomizeButton.tsx
+++ b/src/components/quickplay/CustomizeButton.tsx
@@ -13,6 +13,7 @@ const RESPAWN_STATUS = [
 const CRIT_STATUS = ["", "No"];
 const BETA_STATUS = ["No beta maps", "Only beta maps"];
 const RTD_STATUS = ["", "Only RTD"];
+const CUSTOM_STATUS = ["No modded gameplay", "Only modded gameplay"];
 
 const GAMEMODE_STATUS_LOOKUP = {
   any: "Any game mode",
@@ -76,6 +77,12 @@ export default function CustomizeButton() {
       RTD_STATUS,
       true,
     );
+    const customStatus = genPrefString(
+      "gameplay type",
+      quickplayStore.customGameplay,
+      CUSTOM_STATUS,
+      true,
+    );
     const betaStatus = genPrefString(
       "map status",
       quickplayStore.beta,
@@ -88,6 +95,7 @@ export default function CustomizeButton() {
       critStatus,
       respawnStatus,
       rtdStatus,
+      customStatus,
     ].filter((s) => s);
     return strings.join("; ");
   }, [
@@ -97,6 +105,7 @@ export default function CustomizeButton() {
     quickplayStore.crits,
     quickplayStore.beta,
     quickplayStore.rtd,
+    quickplayStore.customGameplay,
   ]);
 
   return (

--- a/src/components/quickplay/ServerFinder.tsx
+++ b/src/components/quickplay/ServerFinder.tsx
@@ -20,7 +20,7 @@ const MAX_PING = PING_MED - 1;
 
 const BAD_PING_THRESHOLD = (PING_MED + PING_HIGH) / 2;
 
-const TAG_PREFS = ["crits", "respawntimes", "beta", "rtd"];
+const TAG_PREFS = ["crits", "respawntimes", "beta", "rtd", "customGameplay"];
 
 const gamemodeToPrefix = {
   attack_defense: "cp",
@@ -131,6 +131,18 @@ export default function ServerFinder() {
       } else if (v === 1) {
         must("rtd");
       }
+    } else if (pref === "customGameplay") {
+      if (v === 0) {
+        //block all tags that may have custom content
+        mustNot("x10");
+        mustNot("allcrits");
+        mustNot("customweapons");
+        mustNot("rebalance");
+        mustNot("custom");
+      } else if (v === 1) {
+        must("custom");
+        mustNot("vanilla");
+      }
     }
     if (mustHave.length < 1 && mustNotHave.length < 1) {
       console.error("Unexpected tag pref!", pref, v);
@@ -139,6 +151,11 @@ export default function ServerFinder() {
     for (const has of mustHave) {
       if (!tags.has(has)) {
         return false;
+      }
+      if (tags.has("custom")) {
+        if (!tags.has("x10") && !tags.has("allcrits") && !tags.has("customweapons") && !tags.has("rebalance")) {
+          return false;
+        }
       }
     }
     for (const notHas of mustNotHave) {
@@ -800,6 +817,57 @@ export default function ServerFinder() {
                 onClick={() => quickplayStore.setRtd(-1)}
               />
               <label className="form-check-label" htmlFor="rtd-any">
+                Don't care
+              </label>
+            </div>
+          </div>
+          <div className="row mt-4">
+            <h4 style={{ fontWeight: 500 }}>
+              Customized Gameplay{" "}
+              <HelpTooltip
+                id="rtd-help"
+                title="Mods such as custom weapons or rebalance servers. You can change this setting to 'Don't care' to expand the server search pool."
+              />
+            </h4>
+            <div className="form-check">
+              <input
+                className="form-check-input"
+                type="radio"
+                readOnly
+                name="customGameplay"
+                id="customGameplay-0"
+                checked={quickplayStore.customGameplay === 0}
+                onClick={() => quickplayStore.setCustomGameplay(0)}
+              />
+              <label className="form-check-label" htmlFor="customGameplay-0">
+                Disabled
+              </label>
+            </div>
+            <div className="form-check">
+              <input
+                className="form-check-input"
+                type="radio"
+                readOnly
+                name="customGameplay"
+                id="customGameplay-1"
+                checked={quickplayStore.customGameplay === 1}
+                onClick={() => quickplayStore.setCustomGameplay(1)}
+              />
+              <label className="form-check-label" htmlFor="customGameplay-1">
+                Enabled
+              </label>
+            </div>
+            <div className="form-check">
+              <input
+                className="form-check-input"
+                type="radio"
+                readOnly
+                name="customGameplay"
+                id="customGameplay-any"
+                checked={quickplayStore.customGameplay === -1}
+                onClick={() => quickplayStore.setCustomGameplay(-1)}
+              />
+              <label className="form-check-label" htmlFor="customGameplay-any">
                 Don't care
               </label>
             </div>

--- a/src/components/quickplay/ServerFinder.tsx
+++ b/src/components/quickplay/ServerFinder.tsx
@@ -149,13 +149,12 @@ export default function ServerFinder() {
       return true;
     }
     for (const has of mustHave) {
-      if (!tags.has(has)) {
+    if (tags.has("custom")) {
+      if (!tags.has("x10") && !tags.has("allcrits") && !tags.has("customweapons") && !tags.has("rebalance")) {
         return false;
       }
-      if (tags.has("custom")) {
-        if (!tags.has("x10") && !tags.has("allcrits") && !tags.has("customweapons") && !tags.has("rebalance")) {
-          return false;
-        }
+    } else if (!tags.has(has)) {
+        return false;
       }
     }
     for (const notHas of mustNotHave) {

--- a/src/store/quickplay.ts
+++ b/src/store/quickplay.ts
@@ -38,6 +38,8 @@ const useStore = create(
       setBeta: (beta) => set(() => ({ beta })),
       rtd: 0,
       setRtd: (rtd) => set(() => ({ rtd })),
+      customGameplay: 0,
+      setCustomGameplay: (customGameplay) => set(() => ({ customGameplay })),
       blocklist: new Set([]),
       addBlocklist: (steamid) =>
         set((state) => {
@@ -90,6 +92,7 @@ const useStore = create(
         "crits",
         "beta",
         "rtd",
+        "customGameplay",
         "blocklist",
         "mapbans",
         "favorites",


### PR DESCRIPTION
Added an quickplay option for users to choose whether they want modded gameplay (rebalance servers, custom weapons, allcrits, x10, etc) or vanilla gameplay
if vanilla is set, then x10, allcrits, customweapons, rebalance, and custom are added to the blocked tags list, its set to vanilla by default
If modded gameplay is set then it adds "custom" to the mustHave list. Rather than checking to see if the server has the tag "custom", if custom is in the mustHave list then it checks to see if it has any of the tags "rebalance, customweapons, allcrits, x10". If it doesn't then checkTagPref returns false
If "I don't care" is selected then it'll allow both vanilla and modded servers into the possible pool of servers to connect to, and everything else functions the same