### PR TITLE
SteamURI add quickplay connection string

### DIFF
--- a/src/components/quickplay/ServerFinder.tsx
+++ b/src/components/quickplay/ServerFinder.tsx
@@ -546,7 +546,7 @@ export default function ServerFinder() {
 
     const parms = new URLSearchParams(window.location.search);
     if (!parms.has("noconnect")) {
-      window.location.href = `steam://connect/${server.addr}`;
+      window.location.href = `steam://connect/${server.addr}/quickplay_1`;
     }
 
     touchRecentServer(server.addr);


### PR DESCRIPTION
Technically this is workaround since steamURI can't pass a connection string, so we can alternatively use a password. With a bit of work server owners can get the connection password. Currently the only way server owners can tell if a client is from quickplay is if the client uses the [manual connection string](https://github.com/mastercomfig/comfig-app/blob/5997c0a903f6d2dbc71517e4429d73264543e2ee/src/components/quickplay/ServerFinder.tsx#L510).